### PR TITLE
Remove Datum trait in mapper

### DIFF
--- a/src/reduce.rs
+++ b/src/reduce.rs
@@ -303,23 +303,14 @@ pub async fn start_uds_server<T>(m: T) -> Result<(), Box<dyn std::error::Error>>
 where
     T: Reducer + Send + Sync + 'static,
 {
-    shared::write_info_file().map_err(|e| format!("writing info file: {e:?}"))?;
-
-    let path = "/var/run/numaflow/reduce.sock";
-    let path = std::path::Path::new(path);
-    let parent = path.parent().unwrap();
-    std::fs::create_dir_all(parent).map_err(|e| format!("creating directory {parent:?}: {e:?}"))?;
-
-    let uds = tokio::net::UnixListener::bind(path)?;
-    let _uds_stream = tokio_stream::wrappers::UnixListenerStream::new(uds);
-
+    let listener = shared::create_listener_stream()?;
     let reduce_svc = ReduceService {
         handler: Arc::new(m),
     };
 
     tonic::transport::Server::builder()
         .add_service(reduce_server::ReduceServer::new(reduce_svc))
-        .serve_with_incoming(_uds_stream)
+        .serve_with_incoming(listener)
         .await
         .map_err(Into::into)
 }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -3,10 +3,11 @@ use std::{collections::HashMap, io};
 
 use chrono::{DateTime, TimeZone, Timelike, Utc};
 use prost_types::Timestamp;
+use tokio_stream::wrappers::UnixListenerStream;
 use tracing::info;
 
 #[tracing::instrument]
-pub(crate) fn write_info_file() -> io::Result<()> {
+fn write_info_file() -> io::Result<()> {
     let path = if std::env::var_os("NUMAFLOW_POD").is_some() {
         "/var/run/numaflow/server-info"
     } else {
@@ -26,6 +27,18 @@ pub(crate) fn write_info_file() -> io::Result<()> {
     let content = format!("{}U+005C__END__", info);
     info!(path, content, "Writing to file");
     fs::write(path, content)
+}
+
+pub(crate) fn create_listener_stream() -> Result<UnixListenerStream, Box<dyn std::error::Error>> {
+    write_info_file().map_err(|e| format!("writing info file: {e:?}"))?;
+
+    let path = "/var/run/numaflow/map.sock";
+    let path = std::path::Path::new(path);
+    let parent = path.parent().unwrap();
+    std::fs::create_dir_all(parent).map_err(|e| format!("creating directory {parent:?}: {e:?}"))?;
+
+    let uds = tokio::net::UnixListener::bind(path)?;
+    Ok(tokio_stream::wrappers::UnixListenerStream::new(uds))
 }
 
 pub(crate) fn utc_from_timestamp(t: Option<Timestamp>) -> DateTime<Utc> {


### PR DESCRIPTION
This PR changes the input to `map` function from a trait to a concrete struct type. Many of the common Rust server crates seems to use a concrete struct to represent the request eg. [hyper](https://docs.rs/hyper/latest/hyper/struct.Request.html), [axum](https://docs.rs/axum/latest/axum/extract/type.Request.html), [actix_web](https://docs.rs/actix-web/latest/actix_web/struct.HttpRequest.html). As of now, the `read` function in the `source::Sourcer` also accepts a struct as input.

If the current API (i.e, the `MapRequest` struct) needs changes in future, most likely we will be able to abstract that with generics and making the struct fields private.

I directly created the PR since the effort needed for explaining it in an issue would be almost same as implementing the code. If needed, I will revert back to using trait.