### PR TITLE
chore: export proto definitions

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2021"
+indent_style = "Block"

--- a/src/map.rs
+++ b/src/map.rs
@@ -6,7 +6,8 @@ use tonic::{async_trait, Request, Response, Status};
 
 use crate::shared;
 
-mod proto {
+/// Numaflow Map Proto definitions.
+pub mod proto {
     tonic::include_proto!("map.v1");
 }
 

--- a/src/reduce.rs
+++ b/src/reduce.rs
@@ -16,7 +16,8 @@ use crate::shared;
 
 use self::reducer::reduce_server::Reduce;
 
-mod reducer {
+/// Numaflow Reduce Proto definitions.
+pub mod reducer {
     tonic::include_proto!("reduce.v1");
 }
 

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -7,7 +7,7 @@ use tonic::{Request, Status, Streaming};
 
 use crate::shared;
 
-mod proto {
+pub mod proto {
     tonic::include_proto!("sink.v1");
 }
 

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -7,6 +7,7 @@ use tonic::{Request, Status, Streaming};
 
 use crate::shared;
 
+/// Numaflow Sink Proto definitions.
 pub mod proto {
     tonic::include_proto!("sink.v1");
 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -11,7 +11,8 @@ use tokio::sync::mpsc::{self, Sender};
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{async_trait, Request, Response, Status};
 
-mod proto {
+/// Source Proto definitions.
+pub mod proto {
     tonic::include_proto!("source.v1");
 }
 

--- a/src/sourcetransform.rs
+++ b/src/sourcetransform.rs
@@ -6,7 +6,8 @@ use tonic::{async_trait, Request, Response, Status};
 
 use crate::shared::{self, prost_timestamp_from_utc};
 
-mod proto {
+/// Numaflow SourceTransformer Proto definitions.
+pub mod proto {
     tonic::include_proto!("sourcetransformer.v1");
 }
 


### PR DESCRIPTION
We need access to the definitions to create clients from the proto files.