### PR TITLE
chore: retrieve sdk version from env

### DIFF
--- a/src/shared.rs
+++ b/src/shared.rs
@@ -15,6 +15,7 @@ pub(crate) const MAP_MODE_KEY: &str = "MAP_MODE";
 pub(crate) const UNARY_MAP: &str = "unary-map";
 pub(crate) const BATCH_MAP: &str = "batch-map";
 const MINIMUM_NUMAFLOW_VERSION: &str = "1.3.1";
+const SDK_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 // ServerInfo structure to store server-related information
 #[derive(Serialize, Deserialize, Debug)]
@@ -39,11 +40,12 @@ impl ServerInfo {
         let metadata: HashMap<String, String> = HashMap::new();
         // Return the default server info json content
         // Create a ServerInfo object with default values
+        info!("keran is testing, the current sdk version is: {}", SDK_VERSION);
         ServerInfo {
             protocol: "uds".to_string(),
             language: "rust".to_string(),
             minimum_numaflow_version: MINIMUM_NUMAFLOW_VERSION.to_string(),
-            version: "0.0.1".to_string(),
+            version: SDK_VERSION.to_string(),
             metadata: Option::from(metadata),
         }
     }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -15,7 +15,6 @@ pub(crate) const MAP_MODE_KEY: &str = "MAP_MODE";
 pub(crate) const UNARY_MAP: &str = "unary-map";
 pub(crate) const BATCH_MAP: &str = "batch-map";
 const MINIMUM_NUMAFLOW_VERSION: &str = "1.3.1";
-const SDK_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 // ServerInfo structure to store server-related information
 #[derive(Serialize, Deserialize, Debug)]
@@ -40,12 +39,11 @@ impl ServerInfo {
         let metadata: HashMap<String, String> = HashMap::new();
         // Return the default server info json content
         // Create a ServerInfo object with default values
-        info!("keran is testing, the current sdk version is: {}", SDK_VERSION);
         ServerInfo {
             protocol: "uds".to_string(),
             language: "rust".to_string(),
             minimum_numaflow_version: MINIMUM_NUMAFLOW_VERSION.to_string(),
-            version: SDK_VERSION.to_string(),
+            version: "0.0.1".to_string(),
             metadata: Option::from(metadata),
         }
     }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -40,7 +40,6 @@ impl ServerInfo {
         let metadata: HashMap<String, String> = HashMap::new();
         // Return the default server info json content
         // Create a ServerInfo object with default values
-        info!("keran is testing, the current sdk version is: {}", SDK_VERSION);
         ServerInfo {
             protocol: "uds".to_string(),
             language: "rust".to_string(),


### PR DESCRIPTION
### Testing
Manually changed the numaflow platform `MINIMUM_SUPPORTED_SDK_VERSIONS` to ask for minimum rust version `0.0.2`. Ran a monovertex and verified getting.

```
2024-09-08T20:08:56.033906Z  INFO monovertex::server_info: Server info file: ServerInfo { protocol: "uds", language: "rust", minimum_numaflow_version: "1.3.1", version: "0.0.1", metadata: Some({}) }
2024-09-08T20:08:56.034003Z  INFO monovertex::server_info: Version_info: VersionInfo { version: "latest+unknown", build_date: "1970-01-01T00:00:00Z", git_commit: "", git_tag: "", git_tree_state: "", go_version: "unknown", compiler: "", platform: "linux/aarch64" }
2024-09-08T20:08:56.034069Z  WARN monovertex: Error waiting for source server info file: ServerInfoError("SDK version 0.0.1 must be upgraded to at least 0.0.2, in order to work with the current numaflow version")
2024-09-08T20:08:56.034079Z ERROR monovertex: Application error: ForwarderError("Error waiting for server info file")
2024-09-08T20:08:56.034188Z  INFO monovertex: Gracefully Exiting...
```

Made this change, reran the monovertex, the error was gone.

Also used a unit test to verify the value of `env!("CARGO_PKG_VERSION")` is `0.1.1`. 