### PR TITLE
chore: Fix sideinput-udf image build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["numaflow", "examples/*"]
+members = ["numaflow", "examples/*", "examples/sideinput/udf"]
 # Only check / build main crate by default (check all with `--workspace`)
 default-members = ["numaflow"]
 resolver = "2"

--- a/examples/sideinput/Dockerfile
+++ b/examples/sideinput/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /numaflow-rs/examples/sideinput
 RUN cargo build --release
 
 # our final base
-FROM rust AS sideinput
+FROM debian:bullseye AS sideinput
 
 # copy the build artifact from the build stage
 COPY --from=build /numaflow-rs/target/release/sideinput .

--- a/examples/sideinput/udf/Cargo.toml
+++ b/examples/sideinput/udf/Cargo.toml
@@ -5,13 +5,9 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[[bin]]
-name = "server"
-path = "src/main.rs"
-
 [dependencies]
 tonic = "0.10.2"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
-numaflow = { path = "../../../" }
+numaflow = { path = "../../../numaflow" }
 chrono = "0.4.30"
 notify = "6.1.1"

--- a/examples/sideinput/udf/Dockerfile
+++ b/examples/sideinput/udf/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.80-bookworm AS build
+FROM rust:1.82-bullseye AS build
 
 RUN apt-get update
 RUN apt-get install protobuf-compiler -y
@@ -14,9 +14,9 @@ RUN cargo build --release
 FROM debian:bookworm AS sideinput-udf
 
 # copy the build artifact from the build stage
-COPY --from=build /numaflow-rs/examples/sideinput/udf/target/release/server .
+COPY --from=build /numaflow-rs/target/release/sideinput-udf .
 
 RUN mkdir -p /var/numaflow/sideinputs
 
 # set the startup command to run your binary
-CMD ["./server"]
+CMD ["./sideinput-udf"]

--- a/examples/sideinput/udf/Makefile
+++ b/examples/sideinput/udf/Makefile
@@ -14,7 +14,3 @@ image: update
 	-f ${DOCKER_FILE_PATH}  \
 	-t ${IMAGE_REGISTRY} .
 	@if [ "$(PUSH)" = "true" ]; then docker push ${IMAGE_REGISTRY}; fi
-
-.PHONY: clean
-clean:
-	-rm -rf target


### PR DESCRIPTION
The image build started [failing](https://github.com/numaproj/numaflow-rs/actions/runs/11784179136/job/32822829556) after the changes for using cargo workspaces:
```
  ./hack/update_examples.sh --build-push-example examples/sideinput/udf
  shell: /usr/bin/bash -e {0}
Using tag: stable
cargo check
error: current package believes it's in a workspace when it's not:
current:   /home/runner/work/numaflow-rs/numaflow-rs/examples/sideinput/udf/Cargo.toml
workspace: /home/runner/work/numaflow-rs/numaflow-rs/Cargo.toml

this may be fixable by adding `examples/sideinput/udf` to the `workspace.members` array of the manifest located at: /home/runner/work/numaflow-rs/numaflow-rs/Cargo.toml
Alternatively, to keep it out of the workspace, add the package to the `workspace.exclude` array, or add an empty `[workspace]` table to the package's manifest.
make: *** [Makefile:8: update] Error 101
Error: failed to run make image in examples/sideinput/udf
Error: Process completed with exit code 1.
```