### PR TITLE
chore: fix image build issues

### DIFF
--- a/examples/batchmap-flatmap/Cargo.toml
+++ b/examples/batchmap-flatmap/Cargo.toml
@@ -3,11 +3,6 @@ name = "batchmap-flatmap"
 version = "0.1.0"
 edition = "2021"
 
-
-[[bin]]
-name = "server"
-path = "src/main.rs"
-
 [dependencies]
 tonic = "0.12.0"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/mapt-event-time-filter/Dockerfile
+++ b/examples/mapt-event-time-filter/Dockerfile
@@ -14,7 +14,7 @@ RUN cargo build --release
 FROM debian:bullseye AS mapt-event-time-filter
 
 # copy the build artifact from the build stage
-COPY --from=build /numaflow-rs/target/release/mapt-event-time-filter .
+COPY --from=build /numaflow-rs/target/release/source-transformer-event-time-filter .
 
 # set the startup command to run your binary
-CMD ["./mapt-event-time-filter"]
+CMD ["./source-transformer-event-time-filter"]

--- a/examples/sink-log/Cargo.toml
+++ b/examples/sink-log/Cargo.toml
@@ -3,10 +3,6 @@ name = "sink-log"
 version = "0.1.0"
 edition = "2021"
 
-[[bin]]
-name = "server"
-path = "src/main.rs"
-
 [dependencies]
 tonic = "0.12.0"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
https://github.com/numaproj/numaflow-rs/actions/runs/11819933173/job/32933404680

```sh
#15 32.47    Compiling uuid v1.11.0
#15 36.96    Compiling source-transformer-event-time-filter v0.1.0 (/numaflow-rs/examples/mapt-event-time-filter)
#15 41.86     Finished `release` profile [optimized] target(s) in 41.68s
#15 DONE 42.0s

#16 [mapt-event-time-filter 2/2] COPY --from=build /numaflow-rs/target/release/mapt-event-time-filter .
#16 ERROR: failed to calculate checksum of ref 8cee6282-a9d6-484a-bc40-7902f34ccdad::l8rlhx20ui5tz7lbh86ldt9qc: "/numaflow-rs/target/release/mapt-event-time-filter": not found
------
 > [mapt-event-time-filter 2/2] COPY --from=build /numaflow-rs/target/release/mapt-event-time-filter .:
------
Dockerfile:17
--------------------
  15 |     
  16 |     # copy the build artifact from the build stage
  17 | >>> COPY --from=build /numaflow-rs/target/release/mapt-event-time-filter .
  18 |     
  19 |     # set the startup command to run your binary
--------------------
ERROR: failed to solve: failed to compute cache key: failed to calculate checksum of ref 8cee6282-a9d6-484a-bc40-7902f34ccdad::l8rlhx20ui5tz7lbh86ldt9qc: "/numaflow-rs/target/release/mapt-event-time-filter": not found
make: *** [Makefile:13: image] Error 1
Error: failed to run make image in examples/mapt-event-time-filter
Error: Process completed with exit code 1.
```

Tested by:

- Building all images locally ./hack/update_examples.sh --build-push-example examples/mapt-event-time-filter
- Tried running all images to ensure entry point is set correctly.

Temporarily enabled image builds for [the brach ](https://github.com/numaproj/numaflow-rs/pull/104)without pushing: https://github.com/numaproj/numaflow-rs/actions/runs/11849802649/job/33023654421?pr=104