### PR TITLE
feat: change Sourcer API to support sources where pending can not be …

### DIFF
--- a/examples/mapt-event-time-filter/src/main.rs
+++ b/examples/mapt-event-time-filter/src/main.rs
@@ -58,7 +58,7 @@ mod tests {
 
         let messages = filter_event_time(source_request);
 
-        assert_eq!((&messages).len(), 1);
+        assert_eq!(messages.len(), 1);
         assert_eq!((&messages)[0].tags.as_ref().unwrap()[0], "within_year_2022")
     }
 
@@ -76,7 +76,7 @@ mod tests {
 
         let messages = filter_event_time(source_request);
 
-        assert_eq!((&messages).len(), 1);
+        assert_eq!(messages.len(), 1);
         assert_eq!((&messages)[0].tags.as_ref().unwrap()[0], "after_year_2022")
     }
 
@@ -94,7 +94,10 @@ mod tests {
 
         let messages = filter_event_time(source_request);
 
-        assert_eq!((&messages).len(), 1);
-        assert_eq!((&messages)[0].tags.as_ref().unwrap()[0], "U+005C__DROP__")
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages.first().unwrap().tags.as_ref().unwrap()[0],
+            "U+005C__DROP__"
+        )
     }
 }

--- a/examples/simple-source/src/main.rs
+++ b/examples/simple-source/src/main.rs
@@ -68,8 +68,8 @@ pub(crate) mod simple_source {
             }
         }
 
-        async fn pending(&self) -> usize {
-            self.yet_to_ack.read().unwrap().len()
+        async fn pending(&self) -> Option<usize> {
+            self.yet_to_ack.read().unwrap().len().into()
         }
 
         async fn partitions(&self) -> Option<Vec<i32>> {

--- a/numaflow/src/sink.rs
+++ b/numaflow/src/sink.rs
@@ -646,7 +646,7 @@ mod tests {
 
         let resp = resp_stream.message().await.unwrap().unwrap();
         assert!(!resp.results.is_empty());
-        let msg = &resp.results.get(0).unwrap();
+        let msg = resp.results.first().unwrap();
         assert_eq!(msg.err_msg, "");
         assert_eq!(msg.id, "1");
 
@@ -660,7 +660,7 @@ mod tests {
         let resp = resp_stream.message().await.unwrap().unwrap();
         assert!(!resp.results.is_empty());
         assert!(resp.handshake.is_none());
-        let msg = &resp.results.get(0).unwrap();
+        let msg = resp.results.first().unwrap();
         assert_eq!(msg.err_msg, "");
         assert_eq!(msg.id, "2");
 


### PR DESCRIPTION
Changes the trait method `Sourcer::pending` to return `Option<usize>`.  We use `-1` if pending can not be computed and the corresponding method in Golang SDK returns `i64`.