### PR TITLE
Make servers mod public

### DIFF
--- a/numaflow/src/lib.rs
+++ b/numaflow/src/lib.rs
@@ -42,7 +42,7 @@ pub mod mapstream;
 
 pub mod serving_store;
 
-mod servers;
+pub mod servers;
 
 // Error handling on Numaflow SDKs!
 //


### PR DESCRIPTION
This makes the servers mod public.

This is useful when:
* writing proxies that can forward the protocol over another transport
*  writing tests of libraries that use this library.