### PR TITLE
chore: export a few consts

### DIFF
--- a/numaflow/src/batchmap.rs
+++ b/numaflow/src/batchmap.rs
@@ -19,10 +19,10 @@ use crate::shared;
 use shared::{ContainerType, DROP, build_panic_status, get_panic_info};
 
 /// Default socket address for batchmap service
-const SOCK_ADDR: &str = "/var/run/numaflow/batchmap.sock";
+pub const SOCK_ADDR: &str = "/var/run/numaflow/batchmap.sock";
 
 /// Default server info file for batchmap service  
-const SERVER_INFO_FILE: &str = "/var/run/numaflow/mapper-server-info";
+pub const SERVER_INFO_FILE: &str = "/var/run/numaflow/mapper-server-info";
 
 /// Default channel size for batchmap service
 const CHANNEL_SIZE: usize = 1000;

--- a/numaflow/src/map.rs
+++ b/numaflow/src/map.rs
@@ -16,10 +16,10 @@ use crate::shared;
 use shared::{ContainerType, DROP, ServerConfig, SocketCleanup, shutdown_signal};
 
 /// Default socket address for map service
-const SOCK_ADDR: &str = "/var/run/numaflow/map.sock";
+pub const SOCK_ADDR: &str = "/var/run/numaflow/map.sock";
 
 /// Default server info file for map service
-const SERVER_INFO_FILE: &str = "/var/run/numaflow/mapper-server-info";
+pub const SERVER_INFO_FILE: &str = "/var/run/numaflow/mapper-server-info";
 
 /// Default channel size for map service
 const CHANNEL_SIZE: usize = 1000;
@@ -662,9 +662,9 @@ mod tests {
             Duration::from_secs(2),
             client.map_fn(ReceiverStream::new(rx)),
         )
-        .await
-        .map_err(|_| "timeout while getting stream for map_fn")??
-        .into_inner();
+            .await
+            .map_err(|_| "timeout while getting stream for map_fn")??
+            .into_inner();
 
         let handshake_resp = stream.message().await?.unwrap();
         assert!(
@@ -763,9 +763,9 @@ mod tests {
             Duration::from_secs(2),
             client.map_fn(ReceiverStream::new(rx)),
         )
-        .await
-        .map_err(|_| "timeout while getting stream for map_fn")??
-        .into_inner();
+            .await
+            .map_err(|_| "timeout while getting stream for map_fn")??
+            .into_inner();
 
         let handshake_resp = stream.message().await?.unwrap();
         assert!(

--- a/numaflow/src/map.rs
+++ b/numaflow/src/map.rs
@@ -678,9 +678,9 @@ mod tests {
             Duration::from_secs(2),
             client.map_fn(ReceiverStream::new(rx)),
         )
-            .await
-            .map_err(|_| "timeout while getting stream for map_fn")??
-            .into_inner();
+        .await
+        .map_err(|_| "timeout while getting stream for map_fn")??
+        .into_inner();
 
         let handshake_resp = stream.message().await?.unwrap();
         assert!(
@@ -786,9 +786,9 @@ mod tests {
             Duration::from_secs(2),
             client.map_fn(ReceiverStream::new(rx)),
         )
-            .await
-            .map_err(|_| "timeout while getting stream for map_fn")??
-            .into_inner();
+        .await
+        .map_err(|_| "timeout while getting stream for map_fn")??
+        .into_inner();
 
         let handshake_resp = stream.message().await?.unwrap();
         assert!(

--- a/numaflow/src/mapstream.rs
+++ b/numaflow/src/mapstream.rs
@@ -18,10 +18,10 @@ use crate::shared;
 use shared::{ContainerType, DROP, build_panic_status, get_panic_info};
 
 /// Default socket address for mapstream service
-const SOCK_ADDR: &str = "/var/run/numaflow/mapstream.sock";
+pub const SOCK_ADDR: &str = "/var/run/numaflow/mapstream.sock";
 
 /// Default server info file for mapstream service
-const SERVER_INFO_FILE: &str = "/var/run/numaflow/mapper-server-info";
+pub const SERVER_INFO_FILE: &str = "/var/run/numaflow/mapper-server-info";
 
 /// Default channel size for mapstream service
 const CHANNEL_SIZE: usize = 1000;

--- a/numaflow/src/reduce.rs
+++ b/numaflow/src/reduce.rs
@@ -15,10 +15,10 @@ use crate::shared;
 use shared::{ContainerType, DROP, build_panic_status, get_panic_info, prost_timestamp_from_utc};
 use tracing::error;
 /// Default socket address for reduce service
-const SOCK_ADDR: &str = "/var/run/numaflow/reduce.sock";
+pub const SOCK_ADDR: &str = "/var/run/numaflow/reduce.sock";
 
 /// Default server info file for reduce service
-const SERVER_INFO_FILE: &str = "/var/run/numaflow/reducer-server-info";
+pub const SERVER_INFO_FILE: &str = "/var/run/numaflow/reducer-server-info";
 
 const KEY_JOIN_DELIMITER: &str = ":";
 

--- a/numaflow/src/serving_store.rs
+++ b/numaflow/src/serving_store.rs
@@ -13,10 +13,10 @@ use crate::shared;
 use shared::{ContainerType, ServerConfig, SocketCleanup};
 
 /// Default socket address for serving store service
-const SOCK_ADDR: &str = "/var/run/numaflow/serving.sock";
+pub const SOCK_ADDR: &str = "/var/run/numaflow/serving.sock";
 
 /// Default server info file for serving store service
-const SERVER_INFO_FILE: &str = "/var/run/numaflow/serving-server-info";
+pub const SERVER_INFO_FILE: &str = "/var/run/numaflow/serving-server-info";
 
 /// ServingStore trait for implementing user defined stores. This Store has to be
 /// a shared Store between the Source and the Sink vertices. [ServingStore::put] happens in Sink

--- a/numaflow/src/session_reduce.rs
+++ b/numaflow/src/session_reduce.rs
@@ -18,8 +18,9 @@ use shared::{ContainerType, build_panic_status, get_panic_info};
 
 const KEY_JOIN_DELIMITER: &str = ":";
 
-const SOCK_ADDR: &str = "/var/run/numaflow/sessionreduce.sock";
-const SERVER_INFO_FILE: &str = "/var/run/numaflow/sessionreducer-server-info";
+pub const SOCK_ADDR: &str = "/var/run/numaflow/sessionreduce.sock";
+pub const SERVER_INFO_FILE: &str = "/var/run/numaflow/sessionreducer-server-info";
+
 const CHANNEL_SIZE: usize = 100;
 
 /// SessionReducer is the trait which has to be implemented to do a session reduce operation.

--- a/numaflow/src/sideinput.rs
+++ b/numaflow/src/sideinput.rs
@@ -13,9 +13,9 @@ use crate::{
 use shared::{ContainerType, ServerConfig, SocketCleanup, shutdown_signal};
 
 /// Default socket address for sideinput service
-const SOCK_ADDR: &str = "/var/run/numaflow/sideinput.sock";
+pub const SOCK_ADDR: &str = "/var/run/numaflow/sideinput.sock";
 /// Default server info file for sideinput service
-const SERVER_INFO_FILE: &str = "/var/run/numaflow/sideinput-server-info";
+pub const SERVER_INFO_FILE: &str = "/var/run/numaflow/sideinput-server-info";
 
 struct SideInputService<T> {
     handler: Arc<T>,

--- a/numaflow/src/sink.rs
+++ b/numaflow/src/sink.rs
@@ -18,16 +18,16 @@ use crate::shared;
 use shared::{ContainerType, ENV_CONTAINER_TYPE, build_panic_status, get_panic_info};
 
 /// Default socket address for sink service
-const SOCK_ADDR: &str = "/var/run/numaflow/sink.sock";
+pub const SOCK_ADDR: &str = "/var/run/numaflow/sink.sock";
 
 /// Default server info file for sink service
-const SERVER_INFO_FILE: &str = "/var/run/numaflow/sinker-server-info";
+pub const SERVER_INFO_FILE: &str = "/var/run/numaflow/sinker-server-info";
 
 /// Default socket address for fallback sink
-const FB_SOCK_ADDR: &str = "/var/run/numaflow/fb-sink.sock";
+pub const FB_SOCK_ADDR: &str = "/var/run/numaflow/fb-sink.sock";
 
 /// Default server info file for fallback sink
-const FB_SERVER_INFO_FILE: &str = "/var/run/numaflow/fb-sinker-server-info";
+pub const FB_SERVER_INFO_FILE: &str = "/var/run/numaflow/fb-sinker-server-info";
 
 /// Container identifier for fallback sink
 const FB_CONTAINER_TYPE: &str = "fb-udsink";

--- a/numaflow/src/source.rs
+++ b/numaflow/src/source.rs
@@ -18,10 +18,10 @@ use crate::shared;
 use shared::{ContainerType, prost_timestamp_from_utc};
 
 /// Default socket address for source service
-const SOCK_ADDR: &str = "/var/run/numaflow/source.sock";
+pub const SOCK_ADDR: &str = "/var/run/numaflow/source.sock";
 
 /// Default server info file for source service
-const SERVER_INFO_FILE: &str = "/var/run/numaflow/sourcer-server-info";
+pub const SERVER_INFO_FILE: &str = "/var/run/numaflow/sourcer-server-info";
 
 // TODO: use batch-size, blocked by https://github.com/numaproj/numaflow/issues/2026
 /// Default channel size for source service

--- a/numaflow/src/sourcetransform.rs
+++ b/numaflow/src/sourcetransform.rs
@@ -21,10 +21,10 @@ use shared::{
 };
 
 /// Default socket address for source transformer service
-const SOCK_ADDR: &str = "/var/run/numaflow/sourcetransform.sock";
+pub const SOCK_ADDR: &str = "/var/run/numaflow/sourcetransform.sock";
 
 /// Default server info file for source transformer service
-const SERVER_INFO_FILE: &str = "/var/run/numaflow/sourcetransformer-server-info";
+pub const SERVER_INFO_FILE: &str = "/var/run/numaflow/sourcetransformer-server-info";
 
 /// Default channel size for source transformer service
 const CHANNEL_SIZE: usize = 1000;


### PR DESCRIPTION
Export a few constants so that Numaflow SDK can be used as a core SDK for FFI bindings.