### PR TITLE
refactor: making grpc_Service types pub(crate)

### DIFF
--- a/numaflow/src/shared.rs
+++ b/numaflow/src/shared.rs
@@ -17,7 +17,7 @@ pub(crate) const ENV_CONTAINER_TYPE: &str = "NUMAFLOW_UD_CONTAINER_TYPE";
 pub const DROP: &str = "U+005C__DROP__";
 
 // Re-export commonly used items
-pub use grpc_server::{Server, ServerExtras, ServerStarter};
+pub(crate) use grpc_server::{Server, ServerExtras, ServerStarter};
 pub(crate) use panic::{build_panic_status, get_panic_info, init_panic_hook};
 pub use server::ServerConfig;
 pub(crate) use server::{

--- a/numaflow/src/shared.rs
+++ b/numaflow/src/shared.rs
@@ -17,7 +17,7 @@ pub(crate) const ENV_CONTAINER_TYPE: &str = "NUMAFLOW_UD_CONTAINER_TYPE";
 pub const DROP: &str = "U+005C__DROP__";
 
 // Re-export commonly used items
-pub(crate) use grpc_server::{Server, ServerExtras, ServerStarter};
+pub(crate) use grpc_server::{Server, ServerExtras};
 pub(crate) use panic::{build_panic_status, get_panic_info, init_panic_hook};
 pub use server::ServerConfig;
 pub(crate) use server::{

--- a/numaflow/src/shared/grpc_server.rs
+++ b/numaflow/src/shared/grpc_server.rs
@@ -16,6 +16,7 @@ use super::{
 
 /// Trait providing default implementations for common server configuration methods.
 /// This trait works with the builder pattern and eliminates boilerplate delegation code.
+#[allow(dead_code)]
 pub(crate) trait ServerExtras<T> {
     /// Extract the inner server, transform it, and wrap it back
     fn transform_inner<F>(self, f: F) -> Self
@@ -81,9 +82,10 @@ pub(crate) struct ServerStarter {
     init_panic_hook: bool,
 }
 
+#[allow(dead_code)]
 impl ServerStarter {
     /// Create a new server starter with the given container type and defaults
-    pub fn new(
+    pub(crate) fn new(
         container_type: ContainerType,
         default_sock_addr: &str,
         default_server_info_file: &str,
@@ -100,13 +102,13 @@ impl ServerStarter {
     }
 
     /// Set whether to initialize panic hook (default: true)
-    pub fn with_panic_hook(mut self, init_panic_hook: bool) -> Self {
+    pub(crate) fn with_panic_hook(mut self, init_panic_hook: bool) -> Self {
         self.init_panic_hook = init_panic_hook;
         self
     }
 
     /// Set the unix domain socket file path used by the gRPC server to listen for incoming connections.
-    pub fn with_socket_file(mut self, file: impl Into<PathBuf>) -> Self {
+    pub(crate) fn with_socket_file(mut self, file: impl Into<PathBuf>) -> Self {
         let file_path = file.into();
         self.config = self.config.with_socket_file(&file_path);
         self._cleanup = SocketCleanup::new(file_path, self.config.server_info_file().to_path_buf());
@@ -114,23 +116,23 @@ impl ServerStarter {
     }
 
     /// Get the unix domain socket file path where gRPC server listens for incoming connections.
-    pub fn socket_file(&self) -> &std::path::Path {
+    pub(crate) fn socket_file(&self) -> &std::path::Path {
         self.config.socket_file()
     }
 
     /// Set the maximum size of an encoded and decoded gRPC message. The value of `message_size` is in bytes. Default value is 64MB.
-    pub fn with_max_message_size(mut self, message_size: usize) -> Self {
+    pub(crate) fn with_max_message_size(mut self, message_size: usize) -> Self {
         self.config = self.config.with_max_message_size(message_size);
         self
     }
 
     /// Get the maximum size of an encoded and decoded gRPC message in bytes. Default value is 64MB.
-    pub fn max_message_size(&self) -> usize {
+    pub(crate) fn max_message_size(&self) -> usize {
         self.config.max_message_size()
     }
 
     /// Change the file in which numaflow server information is stored on start up to the new value.
-    pub fn with_server_info_file(mut self, file: impl Into<PathBuf>) -> Self {
+    pub(crate) fn with_server_info_file(mut self, file: impl Into<PathBuf>) -> Self {
         let file_path = file.into();
         self.config = self.config.with_server_info_file(&file_path);
         self._cleanup = SocketCleanup::new(self.config.socket_file().to_path_buf(), file_path);
@@ -138,12 +140,12 @@ impl ServerStarter {
     }
 
     /// Get the path to the file where numaflow server info is stored.
-    pub fn server_info_file(&self) -> &std::path::Path {
+    pub(crate) fn server_info_file(&self) -> &std::path::Path {
         self.config.server_info_file()
     }
 
     /// Common server startup logic that can be used by all services
-    pub async fn start_server<F>(
+    pub(crate) async fn start_server<F>(
         self,
         shutdown_rx: Option<oneshot::Receiver<()>>,
         service_builder: F,
@@ -187,9 +189,10 @@ pub(crate) struct Server<T> {
     svc: T,
 }
 
+#[allow(dead_code)]
 impl<T> Server<T> {
     /// Create a new server with the given service and container configuration
-    pub fn new(
+    pub(crate) fn new(
         svc: T,
         container_type: ContainerType,
         default_sock_addr: &str,
@@ -202,7 +205,7 @@ impl<T> Server<T> {
     }
 
     /// Create a new server with custom socket paths (for sink fallback support)
-    pub fn new_with_custom_paths(
+    pub(crate) fn new_with_custom_paths(
         svc: T,
         container_type: ContainerType,
         sock_addr: &str,
@@ -214,41 +217,41 @@ impl<T> Server<T> {
     }
 
     /// Set the unix domain socket file path used by the gRPC server to listen for incoming connections
-    pub fn with_socket_file(mut self, file: impl Into<PathBuf>) -> Self {
+    pub(crate) fn with_socket_file(mut self, file: impl Into<PathBuf>) -> Self {
         self.starter = self.starter.with_socket_file(file);
         self
     }
 
     /// Get the unix domain socket file path where gRPC server listens for incoming connections
-    pub fn socket_file(&self) -> &std::path::Path {
+    pub(crate) fn socket_file(&self) -> &std::path::Path {
         self.starter.socket_file()
     }
 
     /// Set the maximum size of an encoded and decoded gRPC message. The value of `message_size` is in bytes. Default value is 64MB.
-    pub fn with_max_message_size(mut self, message_size: usize) -> Self {
+    pub(crate) fn with_max_message_size(mut self, message_size: usize) -> Self {
         self.starter = self.starter.with_max_message_size(message_size);
         self
     }
 
     /// Get the maximum size of an encoded and decoded gRPC message in bytes. Default value is 64MB.
-    pub fn max_message_size(&self) -> usize {
+    pub(crate) fn max_message_size(&self) -> usize {
         self.starter.max_message_size()
     }
 
     /// Change the file in which numaflow server information is stored on start up to the new value
-    pub fn with_server_info_file(mut self, file: impl Into<PathBuf>) -> Self {
+    pub(crate) fn with_server_info_file(mut self, file: impl Into<PathBuf>) -> Self {
         self.starter = self.starter.with_server_info_file(file);
         self
     }
 
     /// Get the path to the file where numaflow server info is stored
-    pub fn server_info_file(&self) -> &std::path::Path {
+    pub(crate) fn server_info_file(&self) -> &std::path::Path {
         self.starter.server_info_file()
     }
 
     /// Starts the gRPC server with a custom service builder function.
     /// When message is received on the `shutdown` channel, graceful shutdown of the gRPC server will be initiated.
-    pub async fn start_with_shutdown<F>(
+    pub(crate) async fn start_with_shutdown<F>(
         self,
         shutdown_rx: oneshot::Receiver<()>,
         service_builder: F,
@@ -269,7 +272,7 @@ impl<T> Server<T> {
 
     /// Starts the gRPC server with a custom service builder function.
     /// Automatically registers signal handlers for SIGINT and SIGTERM and initiates graceful shutdown of gRPC server when either one of the signal arrives.
-    pub async fn start<F>(
+    pub(crate) async fn start<F>(
         self,
         service_builder: F,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>

--- a/numaflow/src/shared/grpc_server.rs
+++ b/numaflow/src/shared/grpc_server.rs
@@ -16,7 +16,7 @@ use super::{
 
 /// Trait providing default implementations for common server configuration methods.
 /// This trait works with the builder pattern and eliminates boilerplate delegation code.
-pub trait ServerExtras<T> {
+pub(crate) trait ServerExtras<T> {
     /// Extract the inner server, transform it, and wrap it back
     fn transform_inner<F>(self, f: F) -> Self
     where
@@ -74,7 +74,7 @@ pub trait ServerExtras<T> {
 
 /// Common server startup configuration and utilities
 #[derive(Debug)]
-pub struct ServerStarter {
+pub(crate) struct ServerStarter {
     config: ServerConfig,
     container_type: ContainerType,
     _cleanup: SocketCleanup,
@@ -182,7 +182,7 @@ impl ServerStarter {
 /// Generic gRPC server that can handle any service type
 /// This eliminates the need for duplicate Server implementations across all service files
 #[derive(Debug)]
-pub struct Server<T> {
+pub(crate) struct Server<T> {
     starter: ServerStarter,
     svc: T,
 }

--- a/numaflow/src/shared/grpc_server.rs
+++ b/numaflow/src/shared/grpc_server.rs
@@ -251,7 +251,7 @@ impl<T> Server<T> {
 
     /// Starts the gRPC server with a custom service builder function.
     /// When message is received on the `shutdown` channel, graceful shutdown of the gRPC server will be initiated.
-    pub(crate) async fn start_with_shutdown<F>(
+    pub async fn start_with_shutdown<F>(
         self,
         shutdown_rx: oneshot::Receiver<()>,
         service_builder: F,
@@ -272,7 +272,7 @@ impl<T> Server<T> {
 
     /// Starts the gRPC server with a custom service builder function.
     /// Automatically registers signal handlers for SIGINT and SIGTERM and initiates graceful shutdown of gRPC server when either one of the signal arrives.
-    pub(crate) async fn start<F>(
+    pub async fn start<F>(
         self,
         service_builder: F,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>


### PR DESCRIPTION
My Analysis:

We are using pub(crate) to make sure that the grpc_server module visibility is limited to internal implementation kind of encapsulation so that the visibility is only within the crate.

Before changing anything to pub(crate) verified the usage of the trait and the structs that are defined in grpc_server. 
  1. ServerExtra  {trait}  is implemented only by the internal  service wrappers (map::Server , reduce Server ...) and in tests 
  2. ServerStarter {struct} is pure internal implementation never imported outside grpc_Server.rs
  3. Server<T> {struct} is wrapper by each of the services and found that users can directly interact with their respective implementation
 
Also updated the 'shared.rs' to reflect only the internal-visibility of 'grpc_server'

Ran cargo check to verify the cargo is working properly without any probelm.
Ran cargo tests and verifies that all the test cases are running without any errors except for the warnings of the implemented methods not being used  (35 tests + 42 doc tests) 
 
Verified that all the examples are running without any errors 