### PR TITLE
chore: Update cron schedule for sideinput example

### DIFF
--- a/examples/sideinput/manifests/simple-sideinput.yaml
+++ b/examples/sideinput/manifests/simple-sideinput.yaml
@@ -7,10 +7,10 @@ spec:
     - name: myticker
       container:
         image: quay.io/numaio/numaflow-rs/sideinput-example:stable
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
       trigger:
-        schedule: "*/2 * * * *"
-        # timezone: America/Los_Angeles
+        schedule: "0 */2 * * * *"
+        #timezone: America/Los_Angeles
   vertices:
     - name: in
       source:


### PR DESCRIPTION
Update the side input example's manifest to use 6 field cron string instead of 5 field cron string. 
The example otherwise fails with the following error:

```
{"timestamp":"2025-12-04T18:51:15.006992Z","level":"ERROR","message":"Schedule(\"*/2 * * * *\\n         ^\\n\")","target":"numaflow"}
```

follow-up [PR:](https://github.com/numaproj/numaflow/pull/3094) Add a more descriptive error in numaflow core when wrong schedule is set for side-input. 