### PR TITLE
chore: provide a method to configure panic hook when starting a grpc server

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,9 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
 
+      - name: Update archives
+        run: sudo apt-get update
+
       - name: Install dependencies
         run: sudo apt-get install -y protobuf-compiler
 

--- a/numaflow/src/shared/grpc_server.rs
+++ b/numaflow/src/shared/grpc_server.rs
@@ -221,6 +221,12 @@ impl<T> Server<T> {
         self
     }
 
+    /// Set whether to initialize panic hook (default: true)
+    pub(crate) fn with_panic_hook(mut self, init_panic_hook: bool) -> Self {
+        self.starter = self.starter.with_panic_hook(init_panic_hook);
+        self
+    }
+
     /// Get the unix domain socket file path where gRPC server listens for incoming connections
     pub(crate) fn socket_file(&self) -> &std::path::Path {
         self.starter.socket_file()

--- a/numaflow/src/shared/grpc_server.rs
+++ b/numaflow/src/shared/grpc_server.rs
@@ -222,8 +222,8 @@ impl<T> Server<T> {
     }
 
     /// Set whether to initialize panic hook (default: true)
-    pub(crate) fn with_panic_hook(mut self, init_panic_hook: bool) -> Self {
-        self.starter = self.starter.with_panic_hook(init_panic_hook);
+    pub(crate) fn with_panic_hook_disabled(mut self) -> Self {
+        self.starter = self.starter.with_panic_hook(false);
         self
     }
 


### PR DESCRIPTION
With the addition of [test utilities](https://github.com/numaproj/numaflow/pull/3215) that allow running the grpc server on a separate thread, we're able to test for the effect of a server panicking in isolation from the client. 

Although the test threads are isolated from each other, the global panic hook is shared across all threads, leading to it storing the panic error info that it encountered first. This leads to always getting the [same panic info](https://github.com/numaproj/numaflow-rs/blob/main/numaflow/src/shared/panic.rs#L13) from the [panicking grpc servers](https://github.com/numaproj/numaflow-rs/blob/9237e14ac3b28dcd4fbc0e9b9dc470a5258c4dae/numaflow/src/map.rs#L631-L643) during testing. 

It would be great if we can add a method that allows disabling this custom panic hook during server startup for testing so that we can also assert on the error returned by the grpc server. 