### PR TITLE
docs: Example for showcasing stream sorter with ordered processing

### DIFF
--- a/examples/ordered-stream-processing/Cargo.toml
+++ b/examples/ordered-stream-processing/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ordered-stream-processing"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+tonic.workspace = true
+tokio.workspace = true
+numaflow = { path = "../../numaflow" }
+chrono.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+
+[dev-dependencies]
+chrono.workspace = true

--- a/examples/ordered-stream-processing/Dockerfile
+++ b/examples/ordered-stream-processing/Dockerfile
@@ -1,0 +1,20 @@
+FROM rust:1.85-bullseye AS build
+
+RUN apt-get update
+RUN apt-get install protobuf-compiler -y
+
+WORKDIR /numaflow-rs
+COPY ./ ./
+WORKDIR /numaflow-rs/examples/ordered-stream-processing
+
+# build for release
+RUN cargo build --release
+
+# our final base
+FROM debian:bullseye AS ordered-stream-processing
+
+# copy the build artifact from the build stage
+COPY --from=build /numaflow-rs/target/release/ordered-stream-processing .
+
+# set the startup command to run your binary
+CMD ["./ordered-stream-processing"]

--- a/examples/ordered-stream-processing/Makefile
+++ b/examples/ordered-stream-processing/Makefile
@@ -1,0 +1,16 @@
+TAG ?= stable
+PUSH ?= false
+IMAGE_REGISTRY = quay.io/numaio/numaflow-rs/ordered-stream-processing:${TAG}
+DOCKER_FILE_PATH = examples/ordered-stream-processing/Dockerfile
+
+.PHONY: update
+update:
+	cargo check
+	cargo update
+
+.PHONY: image
+image: update
+	cd ../../ && docker build \
+	-f ${DOCKER_FILE_PATH}  \
+	-t ${IMAGE_REGISTRY} .
+	@if [ "$(PUSH)" = "true" ]; then docker push ${IMAGE_REGISTRY}; fi

--- a/examples/ordered-stream-processing/README.md
+++ b/examples/ordered-stream-processing/README.md
@@ -1,0 +1,61 @@
+# Ordered Stream Processing
+
+## Temporal Ordering vs Spatial Ordering
+
+### Temporal Ordering (Stream Sorter / Accumulator)
+
+Events often arrive out of order with respect to their event-time. For example, an event with event-time `t=100` may 
+arrive after an event with event-time `t=200` due to network delays, multi-source ingestion, or upstream processing latencies.
+
+The **stream-sorter accumulator** solves this by buffering incoming events and emitting them sorted by event-time as the 
+watermark advances. It answers: *"Given events that arrived in arbitrary order, can I re-emit them in event-time order?"*
+
+### Spatial Ordering (Ordered Processing)
+
+Even after events are temporally sorted, they can become spatially disordered when a downstream vertex has multiple partitions. 
+By default, Numaflow distributes messages across partitions for throughput, and each partition processes independently — 
+so two messages emitted in order by the sorter may be processed out of order if they land on different partitions that run at different speeds.
+
+**Ordered processing** (`spec.ordered.enabled: true`) solves this by enforcing partitioned FIFO semantics: messages are 
+routed to partitions by key hash, and within each partition, the N-th message is processed only after the (N-1)-th completes. 
+It answers: *"Given events that are already in order, can I guarantee they stay in order throughout the downstream processing?"*
+
+### Why Both Are Needed
+
+| Without stream-sorter | Without ordered processing |
+|---|---|
+| Events arrive out of event-time order | Events may be reordered across partitions |
+| Downstream sees `t=200` before `t=100` | Partition 1 may process `t=200` before partition 2 finishes `t=100` |
+
+Combining both gives an end-to-end guarantee: events are first sorted by event-time (temporal), then processed in that order 
+through all downstream vertices (spatial).
+
+## Pipeline Architecture
+
+```
+input-one (HTTP) ──┐
+                    ├──► sorter (accumulator) ──► order-checker (map, 3 partitions) ──► out (log sink, 3 partitions)
+input-two (HTTP) ──┘
+```
+
+- **input-one, input-two**: HTTP sources. Send events with custom event-times using the `x-numaflow-event-time` header 
+(value in epoch milliseconds). Idle watermark is configured so the pipeline progresses even when sources stop receiving data.
+- **sorter**: Re-uses the `stream-sorter` accumulator to buffer and emit events sorted by event-time.
+- **order-checker**: A map vertex that tracks the last-seen event-time per key and logs whether each arriving event maintains 
+non-decreasing order. This is where you can observe the effect of ordered processing.
+- **out**: A log sink.
+
+## Sending Test Data
+
+Once the pipeline is running, send events with explicit event-times to either HTTP source:
+
+```bash
+# Send events out of temporal order to input-one
+curl -kq -X POST -H "x-numaflow-event-time: 1700000300000" -H "x-numaflow-keys: A" -d '{"seq":3}' https://<input-one-url>
+curl -kq -X POST -H "x-numaflow-event-time: 1700000100000" -H "x-numaflow-keys: A" -d '{"seq":1}' https://<input-one-url>
+curl -kq -X POST -H "x-numaflow-event-time: 1700000200000" -H "x-numaflow-keys: A" -d '{"seq":2}' https://<input-one-url>
+```
+
+The stream-sorter will buffer these and emit them as `seq:1, seq:2, seq:3` once the watermark advances. 
+The order-checker will then confirm they arrive in non-decreasing event-time order, logging `"Order maintained"` for each. 
+If ordering were broken, you would see `"Order violation detected"` warnings in the order-checker logs.

--- a/examples/ordered-stream-processing/manifests/ordered-stream-processing-pipeline.yaml
+++ b/examples/ordered-stream-processing/manifests/ordered-stream-processing-pipeline.yaml
@@ -34,11 +34,6 @@ spec:
             persistentVolumeClaim:
               volumeSize: 10Gi
               accessMode: ReadWriteOnce
-    - name: map-cat
-      udf:
-        container:
-          image: quay.io/numaio/numaflow-rs/map-cat:stable
-          imagePullPolicy: IfNotPresent
     - name: order-checker
       partitions: 3
       udf:
@@ -57,8 +52,6 @@ spec:
     - from: input-two
       to: sorter
     - from: sorter
-      to: map-cat
-    - from: map-cat
       to: order-checker
     - from: order-checker
       to: out

--- a/examples/ordered-stream-processing/manifests/ordered-stream-processing-pipeline.yaml
+++ b/examples/ordered-stream-processing/manifests/ordered-stream-processing-pipeline.yaml
@@ -1,0 +1,55 @@
+apiVersion: numaflow.numaproj.io/v1alpha1
+kind: Pipeline
+metadata:
+  name: ordered-stream-processing
+spec:
+  limits:
+    readBatchSize: 1
+  watermark:
+    idleSource:
+      threshold: 5s
+      incrementBy: 3s
+      stepInterval: 2s
+  ordered:
+    enabled: true
+  vertices:
+    - name: input-one
+      source:
+        http: {}
+    - name: input-two
+      source:
+        http: {}
+    - name: sorter
+      udf:
+        container:
+          # Stream sorter accumulator that sorts events by event-time
+          image: quay.io/numaio/numaflow-rs/stream-sorter:stable
+        groupBy:
+          window:
+            accumulator:
+              timeout: 30s
+          keyed: true
+          storage:
+            persistentVolumeClaim:
+              volumeSize: 10Gi
+              accessMode: ReadWriteOnce
+    - name: order-checker
+      partitions: 2
+      udf:
+        container:
+          # Order-checking map vertex that validates event-time ordering
+          image: quay.io/numaio/numaflow-rs/ordered-stream-processing:stable
+    - name: out
+      partitions: 2
+      sink:
+        # A simple log printing sink
+        log: {}
+  edges:
+    - from: input-one
+      to: sorter
+    - from: input-two
+      to: sorter
+    - from: sorter
+      to: order-checker
+    - from: order-checker
+      to: out

--- a/examples/ordered-stream-processing/manifests/ordered-stream-processing-pipeline.yaml
+++ b/examples/ordered-stream-processing/manifests/ordered-stream-processing-pipeline.yaml
@@ -24,6 +24,7 @@ spec:
         container:
           # Stream sorter accumulator that sorts events by event-time
           image: quay.io/numaio/numaflow-rs/stream-sorter:stable
+          imagePullPolicy: IfNotPresent
         groupBy:
           window:
             accumulator:
@@ -33,14 +34,20 @@ spec:
             persistentVolumeClaim:
               volumeSize: 10Gi
               accessMode: ReadWriteOnce
+    - name: map-cat
+      udf:
+        container:
+          image: quay.io/numaio/numaflow-rs/map-cat:stable
+          imagePullPolicy: IfNotPresent
     - name: order-checker
-      partitions: 2
+      partitions: 3
       udf:
         container:
           # Order-checking map vertex that validates event-time ordering
           image: quay.io/numaio/numaflow-rs/ordered-stream-processing:stable
+          imagePullPolicy: IfNotPresent
     - name: out
-      partitions: 2
+      partitions: 3
       sink:
         # A simple log printing sink
         log: {}
@@ -50,6 +57,8 @@ spec:
     - from: input-two
       to: sorter
     - from: sorter
+      to: map-cat
+    - from: map-cat
       to: order-checker
     - from: order-checker
       to: out

--- a/examples/ordered-stream-processing/src/main.rs
+++ b/examples/ordered-stream-processing/src/main.rs
@@ -1,0 +1,215 @@
+use chrono::{DateTime, Utc};
+use numaflow::map;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use tonic::async_trait;
+use tracing::{info, warn};
+
+/// OrderChecker is a map vertex that validates whether events arrive in non-decreasing
+/// event-time order per key. It tracks the last-seen event-time for each key and logs
+/// whether each incoming event maintains the expected ordering.
+///
+/// This is useful for verifying that upstream sorting (e.g., stream-sorter accumulator)
+/// combined with ordered processing actually delivers events in order.
+struct OrderChecker {
+    /// Tracks the last-seen event-time per key.
+    last_seen: Arc<Mutex<HashMap<Vec<String>, DateTime<Utc>>>>,
+}
+
+impl OrderChecker {
+    fn new() -> Self {
+        Self {
+            last_seen: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+#[async_trait]
+impl map::Mapper for OrderChecker {
+    async fn map(&self, input: map::MapRequest) -> Vec<map::Message> {
+        let current_event_time = input.eventtime;
+        let keys = input.keys.clone();
+
+        let mut state = self.last_seen.lock().unwrap();
+
+        match state.get(&keys) {
+            Some(&last_event_time) if current_event_time < last_event_time => {
+                warn!(
+                    keys = ?keys,
+                    current_event_time = current_event_time.timestamp_millis(),
+                    last_event_time = last_event_time.timestamp_millis(),
+                    "Order violation detected: current event-time is before last seen event-time"
+                );
+            }
+            Some(&last_event_time) => {
+                info!(
+                    keys = ?keys,
+                    current_event_time = current_event_time.timestamp_millis(),
+                    last_event_time = last_event_time.timestamp_millis(),
+                    "Order maintained"
+                );
+            }
+            None => {
+                info!(
+                    keys = ?keys,
+                    current_event_time = current_event_time.timestamp_millis(),
+                    "First event for key"
+                );
+            }
+        }
+
+        state.insert(keys, current_event_time);
+
+        // Log the current state of all tracked keys
+        info!(
+            state = ?state.iter().map(|(k, v)| (k.clone(), v.timestamp_millis())).collect::<Vec<_>>(),
+            "Current order-checker state"
+        );
+
+        vec![map::Message::new(input.value).with_keys(input.keys)]
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    tracing_subscriber::fmt::init();
+
+    info!("Starting order-checker map server");
+
+    map::Server::new(OrderChecker::new()).start().await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use numaflow::map::{MapRequest, Mapper, SystemMetadata, UserMetadata};
+
+    fn create_request(keys: Vec<String>, value: Vec<u8>, eventtime: DateTime<Utc>) -> MapRequest {
+        MapRequest {
+            keys,
+            value,
+            watermark: chrono::Utc::now(),
+            eventtime,
+            headers: HashMap::new(),
+            user_metadata: UserMetadata::new(),
+            system_metadata: SystemMetadata::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_in_order_events() {
+        let checker = OrderChecker::new();
+
+        let t1 = DateTime::from_timestamp(100, 0).unwrap();
+        let t2 = DateTime::from_timestamp(200, 0).unwrap();
+        let t3 = DateTime::from_timestamp(300, 0).unwrap();
+
+        let keys = vec!["key1".to_string()];
+
+        let msgs = checker
+            .map(create_request(keys.clone(), b"a".to_vec(), t1))
+            .await;
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].value, b"a");
+
+        let msgs = checker
+            .map(create_request(keys.clone(), b"b".to_vec(), t2))
+            .await;
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].value, b"b");
+
+        let msgs = checker
+            .map(create_request(keys.clone(), b"c".to_vec(), t3))
+            .await;
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].value, b"c");
+
+        // Verify state tracks the latest event-time
+        let state = checker.last_seen.lock().unwrap();
+        assert_eq!(state.get(&keys), Some(&t3));
+    }
+
+    #[tokio::test]
+    async fn test_out_of_order_detected() {
+        let checker = OrderChecker::new();
+
+        let t1 = DateTime::from_timestamp(200, 0).unwrap();
+        let t2 = DateTime::from_timestamp(100, 0).unwrap(); // Earlier than t1
+
+        let keys = vec!["key1".to_string()];
+
+        checker
+            .map(create_request(keys.clone(), b"a".to_vec(), t1))
+            .await;
+
+        // Out-of-order event still gets forwarded
+        let msgs = checker
+            .map(create_request(keys.clone(), b"b".to_vec(), t2))
+            .await;
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].value, b"b");
+
+        // State is updated to the latest received event-time (even if out of order)
+        let state = checker.last_seen.lock().unwrap();
+        assert_eq!(state.get(&keys), Some(&t2));
+    }
+
+    #[tokio::test]
+    async fn test_independent_key_tracking() {
+        let checker = OrderChecker::new();
+
+        let t1 = DateTime::from_timestamp(100, 0).unwrap();
+        let t2 = DateTime::from_timestamp(200, 0).unwrap();
+
+        let keys_a = vec!["a".to_string()];
+        let keys_b = vec!["b".to_string()];
+
+        checker
+            .map(create_request(keys_a.clone(), b"a1".to_vec(), t2))
+            .await;
+        checker
+            .map(create_request(keys_b.clone(), b"b1".to_vec(), t1))
+            .await;
+
+        let state = checker.last_seen.lock().unwrap();
+        assert_eq!(state.get(&keys_a), Some(&t2));
+        assert_eq!(state.get(&keys_b), Some(&t1));
+    }
+
+    #[tokio::test]
+    async fn test_equal_event_times_are_valid() {
+        let checker = OrderChecker::new();
+
+        let t = DateTime::from_timestamp(100, 0).unwrap();
+        let keys = vec!["key1".to_string()];
+
+        checker
+            .map(create_request(keys.clone(), b"a".to_vec(), t))
+            .await;
+
+        // Same event-time should be treated as in-order
+        let msgs = checker
+            .map(create_request(keys.clone(), b"b".to_vec(), t))
+            .await;
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].value, b"b");
+    }
+
+    #[tokio::test]
+    async fn test_passes_through_keys_and_value() {
+        let checker = OrderChecker::new();
+        let t = DateTime::from_timestamp(100, 0).unwrap();
+
+        let msgs = checker
+            .map(create_request(
+                vec!["k1".to_string(), "k2".to_string()],
+                b"payload".to_vec(),
+                t,
+            ))
+            .await;
+
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].keys, Some(vec!["k1".to_string(), "k2".to_string()]));
+        assert_eq!(msgs[0].value, b"payload");
+    }
+}


### PR DESCRIPTION
Closes https://github.com/numaproj/numaflow/issues/3302

## Testing

Following set of requests were fired off:
```
 ordered-stream-processing % curl -kq -X POST -d "102" -H "x-numaflow-event-time: 1773273996001" -H "x-numaflow-keys: Z" https://localhost:8444/vertices/input-one
 ordered-stream-processing % curl -kq -X POST -d "102" -H "x-numaflow-event-time: 1773274996001" -H "x-numaflow-keys: Z" https://localhost:8445/vertices/input-two
 ordered-stream-processing % curl -kq -X POST -d "102" -H "x-numaflow-event-time: 1773274996001" -H "x-numaflow-keys: Z" https://localhost:8445/vertices/input-two
 ordered-stream-processing % curl -kq -X POST -d "102" -H "x-numaflow-event-time: 1773275996001" -H "x-numaflow-keys: Z" https://localhost:8444/vertices/input-one
 ordered-stream-processing % curl -kq -X POST -d "102" -H "x-numaflow-event-time: 1773273996001" -H "x-numaflow-keys: A" https://localhost:8444/vertices/input-one
 ordered-stream-processing % curl -kq -X POST -d "102" -H "x-numaflow-event-time: 1773274996001" -H "x-numaflow-keys: A" https://localhost:8445/vertices/input-two
 ordered-stream-processing % curl -kq -X POST -d "102" -H "x-numaflow-event-time: 1773275996001" -H "x-numaflow-keys: A" https://localhost:8444/vertices/input-one
 ordered-stream-processing % curl -kq -X POST -d "102" -H "x-numaflow-event-time: 1773276996001" -H "x-numaflow-keys: A" https://localhost:8444/vertices/input-one
 ordered-stream-processing % curl -kq -X POST -d "102" -H "x-numaflow-event-time: 1773276996001" -H "x-numaflow-keys: A" https://localhost:8445/vertices/input-two
 ordered-stream-processing % curl -kq -X POST -d "102" -H "x-numaflow-event-time: 1773276996001" -H "x-numaflow-keys: A" https://localhost:8444/vertices/input-one
```

They contain event times that are not necessarily monotonically increasing for two sets of keys: `A` and `Z`

We see the following logs on `order-checker` partition 0 (replica 0):
```
2026-03-11T20:32:24.119819Z  INFO ordered_stream_processing: First event for key keys=["Z"] current_event_time=1773273996001
2026-03-11T20:32:24.119990Z  INFO ordered_stream_processing: Current order-checker state state=[(["Z"], 1773273996001)]
```

And the following logs on `order-checker` partition 2 (replica 2):
```
2026-03-11T20:34:57.490786Z  INFO ordered_stream_processing: First event for key keys=["A"] current_event_time=1773274996001
2026-03-11T20:34:57.490829Z  INFO ordered_stream_processing: Current order-checker state state=[(["A"], 1773274996001)]
2026-03-11T20:34:57.491045Z  INFO ordered_stream_processing: Order maintained keys=["A"] current_event_time=1773275996001 last_event_time=1773274996001
2026-03-11T20:34:57.491078Z  INFO ordered_stream_processing: Current order-checker state state=[(["A"], 1773275996001)]
2026-03-11T20:34:57.491134Z  INFO ordered_stream_processing: Order maintained keys=["A"] current_event_time=1773276996001 last_event_time=1773275996001
2026-03-11T20:34:57.491149Z  INFO ordered_stream_processing: Current order-checker state state=[(["A"], 1773276996001)]
2026-03-11T20:34:57.491178Z  INFO ordered_stream_processing: Order maintained keys=["A"] current_event_time=1773276996001 last_event_time=1773276996001
2026-03-11T20:34:57.491183Z  INFO ordered_stream_processing: Current order-checker state state=[(["A"], 1773276996001)]
```