### PR TITLE
chore: update rust toolchain image version for all examples

### DIFF
--- a/examples/all-sinks/Dockerfile
+++ b/examples/all-sinks/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85-bullseye AS build
+FROM rust:1.88-bullseye AS build
 
 RUN apt-get update
 RUN apt-get install protobuf-compiler -y

--- a/examples/batchmap-cat/Dockerfile
+++ b/examples/batchmap-cat/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85-bullseye AS build
+FROM rust:1.88-bullseye AS build
 
 RUN apt-get update
 RUN apt-get install protobuf-compiler -y

--- a/examples/batchmap-flatmap/Dockerfile
+++ b/examples/batchmap-flatmap/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85-bullseye AS build
+FROM rust:1.88-bullseye AS build
 
 RUN apt-get update
 RUN apt-get install protobuf-compiler -y

--- a/examples/flatmap-stream/Dockerfile
+++ b/examples/flatmap-stream/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85-bullseye AS build
+FROM rust:1.88-bullseye AS build
 
 RUN apt-get update
 RUN apt-get install protobuf-compiler -y

--- a/examples/map-bypass-cat/Dockerfile
+++ b/examples/map-bypass-cat/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85-bullseye AS build
+FROM rust:1.88-bullseye AS build
 
 RUN apt-get update
 RUN apt-get install protobuf-compiler -y

--- a/examples/map-cat/Dockerfile
+++ b/examples/map-cat/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85-bullseye AS build
+FROM rust:1.88-bullseye AS build
 
 RUN apt-get update
 RUN apt-get install protobuf-compiler -y

--- a/examples/map-even-odd/Dockerfile
+++ b/examples/map-even-odd/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85-bullseye AS build
+FROM rust:1.88-bullseye AS build
 
 RUN apt-get update
 RUN apt-get install protobuf-compiler -y

--- a/examples/map-tickgen-serde/Dockerfile
+++ b/examples/map-tickgen-serde/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85-bullseye AS build
+FROM rust:1.88-bullseye AS build
 
 RUN apt-get update
 RUN apt-get install protobuf-compiler -y

--- a/examples/mapt-event-time-filter/Dockerfile
+++ b/examples/mapt-event-time-filter/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85-bullseye AS build
+FROM rust:1.88-bullseye AS build
 
 RUN apt-get update
 RUN apt-get install protobuf-compiler -y

--- a/examples/redis-sink/Dockerfile
+++ b/examples/redis-sink/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85-bullseye AS build
+FROM rust:1.88-bullseye AS build
 
 RUN apt-get update
 RUN apt-get install protobuf-compiler -y

--- a/examples/reduce-stream-counter/Dockerfile
+++ b/examples/reduce-stream-counter/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85-bullseye AS build
+FROM rust:1.88-bullseye AS build
 
 RUN apt-get update
 RUN apt-get install protobuf-compiler -y

--- a/examples/session-counter/Dockerfile
+++ b/examples/session-counter/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85-bullseye AS build
+FROM rust:1.88-bullseye AS build
 
 RUN apt-get update
 RUN apt-get install protobuf-compiler -y

--- a/examples/sideinput/Dockerfile
+++ b/examples/sideinput/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85-bullseye AS build
+FROM rust:1.88-bullseye AS build
 
 RUN apt-get update
 RUN apt-get install protobuf-compiler -y

--- a/examples/sink-log/Dockerfile
+++ b/examples/sink-log/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85-bullseye AS build
+FROM rust:1.88-bullseye AS build
 
 RUN apt-get update
 RUN apt-get install protobuf-compiler -y

--- a/examples/source-transformer-bypass/Dockerfile
+++ b/examples/source-transformer-bypass/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85-bullseye AS build
+FROM rust:1.88-bullseye AS build
 
 RUN apt-get update
 RUN apt-get install protobuf-compiler -y

--- a/examples/source-transformer-now/Dockerfile
+++ b/examples/source-transformer-now/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85-bullseye AS build
+FROM rust:1.88-bullseye AS build
 
 RUN apt-get update
 RUN apt-get install protobuf-compiler -y

--- a/examples/stream-sorter/Dockerfile
+++ b/examples/stream-sorter/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85-bullseye AS build
+FROM rust:1.88-bullseye AS build
 
 RUN apt-get update
 RUN apt-get install protobuf-compiler -y


### PR DESCRIPTION
[Builds](https://github.com/numaproj/numaflow-rs/actions/runs/27717171535/job/81992976280) for all examples are currently failing with following error:

```
   > [build 7/7] RUN cargo build --release:                                                                                                                                                                                                                                                                               
  ...                                                                                                                                                                                                                                                                                                                     
  4.288   Downloaded linux-raw-sys v0.12.1                                                                                                                                                                                                                                                                                
  4.390 error: rustc 1.85.1 is not supported by the following packages:                                                                                                                                                                                                                                                   
  4.391   tonic@0.14.6 requires rustc 1.88                                                                                                                                                                                                                                                                                
  4.391   tonic-build@0.14.6 requires rustc 1.88                                                                                                                                                                                                                                                                          
  4.391   tonic-prost@0.14.6 requires rustc 1.88                                                                                                                                                                                                                                                                          
  4.391   tonic-prost-build@0.14.6 requires rustc 1.88                                                                                                                                                                                                                                                                    
  4.391   tonic-types@0.14.6 requires rustc 1.88                                                                                                                                                                                                                                                                          
  4.391 Either upgrade rustc or select compatible dependency versions with                                                                                                                                                                                                                                                
  4.391 `cargo update <name>@<current-ver> --precise <compatible-ver>`                                                                                                                                                                                                                                                    
  4.391 where `<compatible-ver>` is the latest version supporting rustc 1.85.1                                                                                                                                                                                                                                            
  4.391                                                                                                                                                                                                                                                                                                                   
  ------                                                                                                                                                                                                                                                                                                                  
  Dockerfile:11                                                                                                                                                                                                                                                                                                           
  --------------------                                                                                                                                                                                                                                                                                                    
     9 |                                                                                                                                                                                                                                                                                                                  
    10 |     # build for release                                                                                                                                                                                                                                                                                          
    11 | >>> RUN cargo build --release                                                                                                                                                                                                                                                                                    
    12 |                                                                                                                                                                                                                                                                                                                  
    13 |     # our final base                                                                                                                                                                                                                                                                                             
  --------------------                                                                                                                                                                                                                                                                                                    
  ERROR: failed to build: failed to solve: process "/bin/sh -c cargo build --release" did not complete successfully: exit code: 101                                                                                                                                                                                       
  make: *** [image] Error 1                                                                                                                                                                                                                                                                                               
  ```                          

So, either we update the rust toolchain version being used or lock the tonic version to a lower value (0.14.5 presumably), I'm choosing to do the former as other crates may soon follow suit. 