### PR TITLE
fix: remove stale UDS file in shared pod volume

### DIFF
--- a/numaflow/src/accumulator.rs
+++ b/numaflow/src/accumulator.rs
@@ -1077,7 +1077,7 @@ mod tests {
 
     async fn setup_server<C: accumulator::AccumulatorCreator + Send + Sync + 'static>(
         creator: C,
-    ) -> Result<(accumulator::Server<C>, PathBuf, PathBuf), Box<dyn Error>> {
+    ) -> Result<(accumulator::Server<C>, PathBuf, PathBuf, TempDir), Box<dyn Error>> {
         let tmp_dir = TempDir::new()?;
         let sock_file = tmp_dir.path().join("accumulator.sock");
         let server_info_file = tmp_dir.path().join("accumulator-server-info");
@@ -1087,7 +1087,7 @@ mod tests {
             .with_socket_file(&sock_file)
             .with_max_message_size(10240);
 
-        Ok((server, sock_file, server_info_file))
+        Ok((server, sock_file, server_info_file, tmp_dir))
     }
 
     async fn setup_client(
@@ -1113,7 +1113,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_server_start() -> Result<(), Box<dyn Error>> {
-        let (server, sock_file, server_info_file) = setup_server(SumCreator).await?;
+        let (server, sock_file, server_info_file, _tmp_dir) = setup_server(SumCreator).await?;
 
         assert_eq!(server.max_message_size(), 10240);
         assert_eq!(server.server_info_file(), server_info_file);
@@ -1147,7 +1147,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_accumulator_operations() -> Result<(), Box<dyn Error>> {
-        let (server, sock_file, _) = setup_server(SumCreator).await?;
+        let (server, sock_file, _, _tmp_dir) = setup_server(SumCreator).await?;
 
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
@@ -1467,7 +1467,7 @@ mod tests {
 
         #[tokio::test]
         async fn test_panic_in_accumulate() -> Result<(), Box<dyn Error>> {
-            let (server, sock_file, _) = setup_server(PanicAccumulatorCreator).await?;
+            let (server, sock_file, _, _tmp_dir) = setup_server(PanicAccumulatorCreator).await?;
 
             let (_shutdown_tx, shutdown_rx) = oneshot::channel();
 

--- a/numaflow/src/reduce.rs
+++ b/numaflow/src/reduce.rs
@@ -875,7 +875,7 @@ mod tests {
 
     async fn setup_server<C: reduce::ReducerCreator + Send + Sync + 'static>(
         creator: C,
-    ) -> Result<(reduce::Server<C>, PathBuf, PathBuf), Box<dyn Error>> {
+    ) -> Result<(reduce::Server<C>, PathBuf, PathBuf, TempDir), Box<dyn Error>> {
         let tmp_dir = TempDir::new()?;
         let sock_file = tmp_dir.path().join("reduce.sock");
         let server_info_file = tmp_dir.path().join("reducer-server-info");
@@ -885,7 +885,7 @@ mod tests {
             .with_socket_file(&sock_file)
             .with_max_message_size(10240);
 
-        Ok((server, sock_file, server_info_file))
+        Ok((server, sock_file, server_info_file, tmp_dir))
     }
 
     async fn setup_client(
@@ -911,7 +911,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_server_start() -> Result<(), Box<dyn Error>> {
-        let (server, sock_file, server_info_file) = setup_server(SumCreator).await?;
+        let (server, sock_file, server_info_file, _tmp_dir) = setup_server(SumCreator).await?;
 
         assert_eq!(server.max_message_size(), 10240);
         assert_eq!(server.server_info_file(), server_info_file);
@@ -945,7 +945,7 @@ mod tests {
 
     #[tokio::test]
     async fn valid_input() -> Result<(), Box<dyn Error>> {
-        let (server, sock_file, _) = setup_server(SumCreator).await?;
+        let (server, sock_file, _, _tmp_dir) = setup_server(SumCreator).await?;
 
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
@@ -1055,7 +1055,7 @@ mod tests {
 
     #[tokio::test]
     async fn invalid_input() -> Result<(), Box<dyn Error>> {
-        let (server, sock_file, _) = setup_server(SumCreator).await?;
+        let (server, sock_file, _, _tmp_dir) = setup_server(SumCreator).await?;
 
         let (_shutdown_tx, shutdown_rx) = oneshot::channel();
 
@@ -1196,7 +1196,7 @@ mod tests {
 
         #[tokio::test]
         async fn panic_in_reduce() -> Result<(), Box<dyn Error>> {
-            let (server, sock_file, _) = setup_server(SimplePanicReducerCreator).await?;
+            let (server, sock_file, _, _tmp_dir) = setup_server(SimplePanicReducerCreator).await?;
 
             let (_shutdown_tx, shutdown_rx) = oneshot::channel();
 
@@ -1272,7 +1272,8 @@ mod tests {
         // processed successfully since we do graceful shutdown of the server.
         #[tokio::test]
         async fn panic_with_multiple_keys() -> Result<(), Box<dyn Error>> {
-            let (server, sock_file, _) = setup_server(ConditionalPanicReducerCreator).await?;
+            let (server, sock_file, _, _tmp_dir) =
+                setup_server(ConditionalPanicReducerCreator).await?;
 
             let (_shutdown_tx, shutdown_rx) = oneshot::channel();
 

--- a/numaflow/src/reducestream.rs
+++ b/numaflow/src/reducestream.rs
@@ -795,7 +795,7 @@ mod tests {
 
     async fn setup_server<C: reducestream::ReduceStreamerCreator + Send + Sync + 'static>(
         creator: C,
-    ) -> Result<(reducestream::Server<C>, PathBuf, PathBuf), Box<dyn Error>> {
+    ) -> Result<(reducestream::Server<C>, PathBuf, PathBuf, TempDir), Box<dyn Error>> {
         let tmp_dir = TempDir::new()?;
         let sock_file = tmp_dir.path().join("reducestream.sock");
         let server_info_file = tmp_dir.path().join("reducestreamer-server-info");
@@ -805,7 +805,7 @@ mod tests {
             .with_socket_file(&sock_file)
             .with_max_message_size(10240);
 
-        Ok((server, sock_file, server_info_file))
+        Ok((server, sock_file, server_info_file, tmp_dir))
     }
 
     async fn setup_client(
@@ -829,7 +829,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_server_start() -> Result<(), Box<dyn Error>> {
-        let (server, sock_file, server_info_file) = setup_server(StreamingSumCreator).await?;
+        let (server, sock_file, server_info_file, _tmp_dir) =
+            setup_server(StreamingSumCreator).await?;
 
         assert_eq!(server.max_message_size(), 10240);
         assert_eq!(server.server_info_file(), server_info_file);
@@ -863,7 +864,7 @@ mod tests {
 
     #[tokio::test]
     async fn streaming_sum_test() -> Result<(), Box<dyn Error>> {
-        let (server, sock_file, _) = setup_server(StreamingSumCreator).await?;
+        let (server, sock_file, _, _tmp_dir) = setup_server(StreamingSumCreator).await?;
 
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
 

--- a/numaflow/src/session_reduce.rs
+++ b/numaflow/src/session_reduce.rs
@@ -1101,7 +1101,7 @@ mod tests {
 
     async fn setup_server<C: session_reduce::SessionReducerCreator + Send + Sync + 'static>(
         creator: C,
-    ) -> Result<(session_reduce::Server<C>, PathBuf, PathBuf), Box<dyn Error>> {
+    ) -> Result<(session_reduce::Server<C>, PathBuf, PathBuf, TempDir), Box<dyn Error>> {
         let tmp_dir = TempDir::new()?;
         let sock_file = tmp_dir.path().join("sessionreduce.sock");
         let server_info_file = tmp_dir.path().join("sessionreducer-server-info");
@@ -1111,7 +1111,7 @@ mod tests {
             .with_socket_file(&sock_file)
             .with_max_message_size(10240);
 
-        Ok((server, sock_file, server_info_file))
+        Ok((server, sock_file, server_info_file, tmp_dir))
     }
 
     async fn setup_client(
@@ -1137,7 +1137,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_server_start() -> Result<(), Box<dyn Error>> {
-        let (server, sock_file, server_info_file) = setup_server(SumCreator).await?;
+        let (server, sock_file, server_info_file, _tmp_dir) = setup_server(SumCreator).await?;
 
         assert_eq!(server.max_message_size(), 10240);
         assert_eq!(server.server_info_file(), server_info_file);
@@ -1171,7 +1171,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_session_reduce_operations() -> Result<(), Box<dyn Error>> {
-        let (server, sock_file, _) = setup_server(SumCreator).await?;
+        let (server, sock_file, _, _tmp_dir) = setup_server(SumCreator).await?;
 
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
@@ -1340,7 +1340,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_invalid_input() -> Result<(), Box<dyn Error>> {
-        let (server, sock_file, _) = setup_server(SumCreator).await?;
+        let (server, sock_file, _, _tmp_dir) = setup_server(SumCreator).await?;
 
         let (_shutdown_tx, shutdown_rx) = oneshot::channel();
 
@@ -1461,7 +1461,7 @@ mod tests {
 
         #[tokio::test]
         async fn test_panic_in_session_reduce() -> Result<(), Box<dyn Error>> {
-            let (server, sock_file, _) = setup_server(PanicSessionReducerCreator).await?;
+            let (server, sock_file, _, _tmp_dir) = setup_server(PanicSessionReducerCreator).await?;
 
             let (_shutdown_tx, shutdown_rx) = oneshot::channel();
 
@@ -1543,7 +1543,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_merge_operations() -> Result<(), Box<dyn Error>> {
-        let (server, sock_file, _) = setup_server(SumCreator).await?;
+        let (server, sock_file, _, _tmp_dir) = setup_server(SumCreator).await?;
 
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
 

--- a/numaflow/src/shared/server.rs
+++ b/numaflow/src/shared/server.rs
@@ -5,6 +5,8 @@
 
 use std::fs;
 use std::io;
+use std::io::ErrorKind;
+use std::os::unix::fs::FileTypeExt;
 use std::path::{Path, PathBuf};
 use tokio::net::UnixListener;
 use tokio::signal;
@@ -214,16 +216,70 @@ fn write_info_file(path: impl AsRef<Path>, server_info: ServerInfo) -> io::Resul
     fs::write(path, content)
 }
 
+/// Remove a stale Unix domain socket path before binding.
+///
+/// A hard-killed container can leave the socket file behind in the shared pod
+/// volume. Only remove it when it is actually a socket; any other file type at
+/// this path is treated as a configuration or ownership error.
+fn remove_stale_socket(socket_file: &Path) -> io::Result<()> {
+    if let Some(parent) = socket_file
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent)?;
+    }
+
+    match fs::symlink_metadata(socket_file) {
+        Ok(metadata) if metadata.file_type().is_socket() => fs::remove_file(socket_file),
+        Ok(_) => Err(io::Error::new(
+            ErrorKind::AlreadyExists,
+            format!(
+                "path exists and is not a Unix socket: {}",
+                socket_file.display()
+            ),
+        )),
+        Err(e) if e.kind() == ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+/// Remove stale server-info so readiness is advertised only after a fresh bind.
+fn remove_server_info_file(server_info_file: &Path) -> io::Result<()> {
+    match fs::remove_file(server_info_file) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
 /// Create a Unix listener stream for the gRPC server
 pub fn create_listener_stream(
     socket_file: impl AsRef<Path>,
     server_info_file: impl AsRef<Path>,
     server_info: ServerInfo,
 ) -> Result<UnixListenerStream, Box<dyn std::error::Error + Send + Sync>> {
-    write_info_file(server_info_file, server_info)
-        .map_err(|e| format!("writing info file: {e:?}"))?;
+    let socket_file = socket_file.as_ref();
+    let server_info_file = server_info_file.as_ref();
 
-    let uds_stream = UnixListener::bind(socket_file)?;
+    remove_server_info_file(server_info_file)
+        .map_err(|e| format!("removing stale server info file {server_info_file:?}: {e:?}"))?;
+    remove_stale_socket(socket_file)
+        .map_err(|e| format!("removing stale socket file {socket_file:?}: {e:?}"))?;
+    let uds_stream = match UnixListener::bind(socket_file) {
+        Ok(uds_stream) => uds_stream,
+        Err(e) => {
+            let _ = fs::remove_file(socket_file);
+            let _ = fs::remove_file(server_info_file);
+            return Err(format!("binding Unix socket {socket_file:?}: {e:?}").into());
+        }
+    };
+
+    if let Err(e) = write_info_file(server_info_file, server_info) {
+        let _ = fs::remove_file(socket_file);
+        let _ = fs::remove_file(server_info_file);
+        return Err(format!("writing info file: {e:?}").into());
+    }
+
     Ok(UnixListenerStream::new(uds_stream))
 }
 

--- a/numaflow/src/shared/server.rs
+++ b/numaflow/src/shared/server.rs
@@ -222,13 +222,6 @@ fn write_info_file(path: impl AsRef<Path>, server_info: ServerInfo) -> io::Resul
 /// volume. Only remove it when it is actually a socket; any other file type at
 /// this path is treated as a configuration or ownership error.
 fn remove_stale_socket(socket_file: &Path) -> io::Result<()> {
-    if let Some(parent) = socket_file
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-    {
-        fs::create_dir_all(parent)?;
-    }
-
     match fs::symlink_metadata(socket_file) {
         Ok(metadata) if metadata.file_type().is_socket() => fs::remove_file(socket_file),
         Ok(_) => Err(io::Error::new(
@@ -243,6 +236,17 @@ fn remove_stale_socket(socket_file: &Path) -> io::Result<()> {
     }
 }
 
+fn create_parent_dir(path: &Path) -> io::Result<()> {
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent)?;
+    }
+
+    Ok(())
+}
+
 /// Remove stale server-info so readiness is advertised only after a fresh bind.
 fn remove_server_info_file(server_info_file: &Path) -> io::Result<()> {
     match fs::remove_file(server_info_file) {
@@ -253,6 +257,7 @@ fn remove_server_info_file(server_info_file: &Path) -> io::Result<()> {
 }
 
 /// Create a Unix listener stream for the gRPC server
+/// First, bind to the socket file and then write the server info to the file.
 pub fn create_listener_stream(
     socket_file: impl AsRef<Path>,
     server_info_file: impl AsRef<Path>,
@@ -261,6 +266,8 @@ pub fn create_listener_stream(
     let socket_file = socket_file.as_ref();
     let server_info_file = server_info_file.as_ref();
 
+    create_parent_dir(socket_file)
+        .map_err(|e| format!("creating socket parent directory {socket_file:?}: {e:?}"))?;
     remove_server_info_file(server_info_file)
         .map_err(|e| format!("removing stale server info file {server_info_file:?}: {e:?}"))?;
     remove_stale_socket(socket_file)
@@ -268,7 +275,6 @@ pub fn create_listener_stream(
     let uds_stream = match UnixListener::bind(socket_file) {
         Ok(uds_stream) => uds_stream,
         Err(e) => {
-            let _ = fs::remove_file(socket_file);
             let _ = fs::remove_file(server_info_file);
             return Err(format!("binding Unix socket {socket_file:?}: {e:?}").into());
         }

--- a/numaflow/src/shared/server.rs
+++ b/numaflow/src/shared/server.rs
@@ -236,17 +236,6 @@ fn remove_stale_socket(socket_file: &Path) -> io::Result<()> {
     }
 }
 
-fn create_parent_dir(path: &Path) -> io::Result<()> {
-    if let Some(parent) = path
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-    {
-        fs::create_dir_all(parent)?;
-    }
-
-    Ok(())
-}
-
 /// Remove stale server-info so readiness is advertised only after a fresh bind.
 fn remove_server_info_file(server_info_file: &Path) -> io::Result<()> {
     match fs::remove_file(server_info_file) {
@@ -266,8 +255,6 @@ pub fn create_listener_stream(
     let socket_file = socket_file.as_ref();
     let server_info_file = server_info_file.as_ref();
 
-    create_parent_dir(socket_file)
-        .map_err(|e| format!("creating socket parent directory {socket_file:?}: {e:?}"))?;
     remove_server_info_file(server_info_file)
         .map_err(|e| format!("removing stale server info file {server_info_file:?}: {e:?}"))?;
     remove_stale_socket(socket_file)
@@ -435,5 +422,29 @@ mod tests {
 
         let metadata = info.metadata.unwrap();
         assert!(metadata.is_empty()); // Source doesn't have MAP_MODE
+    }
+
+    #[tokio::test]
+    async fn test_create_listener_stream_removes_stale_socket()
+    -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let tmp_dir = tempfile::tempdir()?;
+        let socket_file = tmp_dir.path().join("stale.sock");
+        let server_info_file = tmp_dir.path().join("server-info");
+
+        let stale_listener = UnixListener::bind(&socket_file)?;
+        drop(stale_listener);
+
+        let listener = create_listener_stream(
+            &socket_file,
+            &server_info_file,
+            ServerInfo::new(ContainerType::Source),
+        )?;
+
+        assert!(socket_file.exists());
+        assert!(server_info_file.exists());
+        drop(listener);
+        let _ = fs::remove_file(socket_file);
+
+        Ok(())
     }
 }


### PR DESCRIPTION
### Summary
- Remove stale Unix domain socket files before binding SDK UDS servers.
- Reject existing non-socket paths with a clear error instead of overwriting them.
- Write `server-info` only after the socket bind succeeds
-  keep temp dirs alive for UDS server tests

### Issue observed while testing

In the SDK, a hard killed UDF sidecar left its UDS file in /var/run/numaflow. On restart, the SDK tried to bind the same socket path without removing the stale file, causing `Address already in use` and leaving the sidecar in `CrashLoopBackOff`.

This prevented numa from reconnecting until the stale socket was manually deleted.

https://github.com/numaproj/numaflow/issues/3368

JAVA sdk deletes [here](https://github.com/numaproj/numaflow-java/blob/0c3b01cbafce3b5917590b50828c99ce850b2338/src/main/java/io/numaproj/numaflow/shared/GrpcServerUtils.java#L85)

GO sdk deletes [here](https://github.com/numaproj/numaflow-go/blob/6f4297d8e5eee21d196a693ce744ab493fa9def7/internal/shared/util.go#L40)  